### PR TITLE
Fix GHA: ubuntu-latest no longer contains Python 3.5 and 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu
+        - ["ubuntu", "ubuntu-20.04"]
         config:
         # [Python version, tox env]
         - ["3.9",   "lint"]
@@ -28,21 +28,23 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
+        - ["3.11",  "py311"]
         - ["pypy-2.7", "pypy"]
         - ["pypy-3.7", "pypy3"]
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os[1] }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "dbaca5f3c7785b7bca563dabc5f440544069a8f9"
+commit-id = "200573eb414d2228d463da3de7d71a6d6335a704"
 
 [python]
 with-windows = false
@@ -11,6 +11,7 @@ with-future-python = false
 with-legacy-python = true
 with-docs = true
 with-sphinx-doctests = false
+with-macos = false
 
 [tox]
 use-flake8 = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 2.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add support for Python 3.11.
 
 
 2.2 (2022-04-29)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py38
     py39
     py310
+    py311
     pypy
     pypy3
     docs
@@ -41,6 +42,7 @@ deps =
 
 [testenv:isort-apply]
 basepython = python3
+skip_install = true
 commands_pre =
 deps =
     isort
@@ -66,8 +68,8 @@ deps =
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
-    coverage html
-    coverage report -m --fail-under=100
+    coverage html --ignore-errors
+    coverage report --ignore-errors --show-missing --fail-under=100
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Add support for Python 3.11.